### PR TITLE
Add due date feature to tasks (fixes #4)

### DIFF
--- a/taskmaster/cli.py
+++ b/taskmaster/cli.py
@@ -49,7 +49,8 @@ def main():
     help="Task priority"
 )
 @click.option("-t", "--tag", multiple=True, help="Add tags to the task")
-def add(title: str, description: str, priority: str, tag: tuple):
+@click.option("--due", default=None, help="Due date (YYYY-MM-DD format)")
+def add(title: str, description: str, priority: str, tag: tuple, due: str):
     """Add a new task."""
     manager = TaskManager()
     task = manager.add_task(
@@ -57,8 +58,13 @@ def add(title: str, description: str, priority: str, tag: tuple):
         description=description,
         priority=priority,
         tags=list(tag),
+        due_date=due,
     )
-    console.print(f"[green]Created task:[/green] {task.title} [dim](ID: {task.id})[/dim]")
+    due_str = ""
+    if task.due_date:
+        due_str = f" [dim](Due: {task.due_date.strftime('%Y-%m-%d')})[/dim]"
+    msg = f"[green]Created task:[/green] {task.title} [dim](ID: {task.id})[/dim]"
+    console.print(f"{msg}{due_str}")
 
 
 @main.command()
@@ -86,6 +92,7 @@ def list(status: str, priority: str):
     table.add_column("Title")
     table.add_column("Priority")
     table.add_column("Status")
+    table.add_column("Due Date")
     table.add_column("Tags")
 
     for task in tasks:
@@ -93,11 +100,19 @@ def list(status: str, priority: str):
         status_style = get_status_color(task.status)
         tags_str = ", ".join(task.tags) if task.tags else "-"
 
+        if task.due_date:
+            due_str = task.due_date.strftime("%Y-%m-%d")
+            if task.is_overdue:
+                due_str = f"[red bold]{due_str}[/red bold]"
+        else:
+            due_str = "-"
+
         table.add_row(
             task.id,
             task.title,
             f"[{priority_style}]{task.priority.value}[/{priority_style}]",
             f"[{status_style}]{task.status.value}[/{status_style}]",
+            due_str,
             tags_str,
         )
 
@@ -142,8 +157,16 @@ def show(task_id: str):
     console.print(f"\n[bold]{task.title}[/bold]")
     console.print(f"[dim]ID: {task.id}[/dim]")
     console.print(f"Description: {task.description or '(none)'}")
-    console.print(f"Priority: [{get_priority_color(task.priority)}]{task.priority.value}[/{get_priority_color(task.priority)}]")
-    console.print(f"Status: [{get_status_color(task.status)}]{task.status.value}[/{get_status_color(task.status)}]")
+    p_color = get_priority_color(task.priority)
+    console.print(f"Priority: [{p_color}]{task.priority.value}[/{p_color}]")
+    s_color = get_status_color(task.status)
+    console.print(f"Status: [{s_color}]{task.status.value}[/{s_color}]")
+    if task.due_date:
+        due_style = "red bold" if task.is_overdue else "white"
+        due_fmt = task.due_date.strftime('%Y-%m-%d %H:%M')
+        console.print(f"Due Date: [{due_style}]{due_fmt}[/{due_style}]")
+    else:
+        console.print("Due Date: (none)")
     console.print(f"Tags: {', '.join(task.tags) if task.tags else '(none)'}")
     console.print(f"Created: {task.created_at.strftime('%Y-%m-%d %H:%M')}")
     console.print(f"Updated: {task.updated_at.strftime('%Y-%m-%d %H:%M')}")

--- a/taskmaster/models.py
+++ b/taskmaster/models.py
@@ -1,10 +1,10 @@
 """Data models for TaskMaster."""
 
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Optional
-import uuid
 
 
 class Priority(Enum):
@@ -31,9 +31,19 @@ class Task:
     priority: Priority = Priority.MEDIUM
     status: Status = Status.PENDING
     tags: list[str] = field(default_factory=list)
+    due_date: Optional[datetime] = None
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
     id: str = field(default_factory=lambda: str(uuid.uuid4())[:8])
+
+    @property
+    def is_overdue(self) -> bool:
+        """Check if the task is overdue."""
+        if self.due_date is None:
+            return False
+        if self.status == Status.COMPLETED:
+            return False
+        return datetime.now() > self.due_date
 
     def mark_complete(self) -> None:
         """Mark the task as completed."""
@@ -54,6 +64,7 @@ class Task:
             "priority": self.priority.value,
             "status": self.status.value,
             "tags": self.tags,
+            "due_date": self.due_date.isoformat() if self.due_date else None,
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
         }
@@ -61,6 +72,8 @@ class Task:
     @classmethod
     def from_dict(cls, data: dict) -> "Task":
         """Create a Task from a dictionary."""
+        due_date_str = data.get("due_date")
+        due_date = datetime.fromisoformat(due_date_str) if due_date_str else None
         return cls(
             id=data["id"],
             title=data["title"],
@@ -68,6 +81,7 @@ class Task:
             priority=Priority(data.get("priority", "medium")),
             status=Status(data.get("status", "pending")),
             tags=data.get("tags", []),
+            due_date=due_date,
             created_at=datetime.fromisoformat(data["created_at"]),
             updated_at=datetime.fromisoformat(data["updated_at"]),
         )

--- a/taskmaster/storage.py
+++ b/taskmaster/storage.py
@@ -88,14 +88,27 @@ class TaskManager:
                 self._task_list = TaskList(name="My Tasks")
         return self._task_list
 
-    def add_task(self, title: str, description: str = "", priority: str = "medium", tags: list[str] = None) -> Task:
+    def add_task(
+        self,
+        title: str,
+        description: str = "",
+        priority: str = "medium",
+        tags: list[str] = None,
+        due_date: str = None,
+    ) -> Task:
         """Add a new task."""
+        from datetime import datetime
+
         from .models import Priority
+        parsed_due_date = None
+        if due_date:
+            parsed_due_date = datetime.fromisoformat(due_date)
         task = Task(
             title=title,
             description=description,
             priority=Priority(priority),
             tags=tags or [],
+            due_date=parsed_due_date,
         )
         self.task_list.add_task(task)
         self.storage.save(self.task_list)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,8 @@
 """Tests for TaskMaster models."""
 
-import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 
-from taskmaster.models import Task, TaskList, Priority, Status
+from taskmaster.models import Priority, Status, Task, TaskList
 
 
 class TestTask:
@@ -17,6 +16,7 @@ class TestTask:
         assert task.priority == Priority.MEDIUM
         assert task.status == Status.PENDING
         assert task.tags == []
+        assert task.due_date is None
         assert task.id is not None
 
     def test_create_task_with_all_fields(self):
@@ -72,6 +72,76 @@ class TestTask:
         assert task.title == "Test task"
         assert task.priority == Priority.HIGH
         assert task.status == Status.IN_PROGRESS
+
+    def test_create_task_with_due_date(self):
+        """Test creating a task with a due date."""
+        due = datetime.now() + timedelta(days=7)
+        task = Task(title="Task with due date", due_date=due)
+        assert task.due_date == due
+        assert task.is_overdue is False
+
+    def test_task_is_overdue(self):
+        """Test that a task is correctly identified as overdue."""
+        past_date = datetime.now() - timedelta(days=1)
+        task = Task(title="Overdue task", due_date=past_date)
+        assert task.is_overdue is True
+
+    def test_task_not_overdue_when_completed(self):
+        """Test that a completed task is not marked as overdue."""
+        past_date = datetime.now() - timedelta(days=1)
+        task = Task(title="Completed task", due_date=past_date)
+        task.mark_complete()
+        assert task.is_overdue is False
+
+    def test_task_not_overdue_without_due_date(self):
+        """Test that a task without due date is not overdue."""
+        task = Task(title="No due date")
+        assert task.is_overdue is False
+
+    def test_to_dict_with_due_date(self):
+        """Test converting task with due date to dictionary."""
+        due = datetime(2024, 6, 15, 10, 0, 0)
+        task = Task(title="Test task", due_date=due)
+        data = task.to_dict()
+        assert data["due_date"] == "2024-06-15T10:00:00"
+
+    def test_to_dict_without_due_date(self):
+        """Test converting task without due date to dictionary."""
+        task = Task(title="Test task")
+        data = task.to_dict()
+        assert data["due_date"] is None
+
+    def test_from_dict_with_due_date(self):
+        """Test creating task from dictionary with due date."""
+        data = {
+            "id": "abc123",
+            "title": "Test task",
+            "description": "Description",
+            "priority": "high",
+            "status": "pending",
+            "tags": [],
+            "due_date": "2024-06-15T10:00:00",
+            "created_at": "2024-01-01T10:00:00",
+            "updated_at": "2024-01-01T11:00:00",
+        }
+        task = Task.from_dict(data)
+        assert task.due_date == datetime(2024, 6, 15, 10, 0, 0)
+
+    def test_from_dict_without_due_date(self):
+        """Test creating task from dictionary without due date."""
+        data = {
+            "id": "abc123",
+            "title": "Test task",
+            "description": "Description",
+            "priority": "high",
+            "status": "pending",
+            "tags": [],
+            "due_date": None,
+            "created_at": "2024-01-01T10:00:00",
+            "updated_at": "2024-01-01T11:00:00",
+        }
+        task = Task.from_dict(data)
+        assert task.due_date is None
 
 
 class TestTaskList:


### PR DESCRIPTION
## Summary

Implements the due date feature requested in Issue #4.

## Changes

- Add `due_date: Optional[datetime]` field to Task model
- Add `is_overdue` property to check if task is past due date
- Update `to_dict()` and `from_dict()` for due_date serialization
- Add `--due` option to CLI `add` command
- Display due date in `list` and `show` commands with overdue highlighting (red)
- Add 8 comprehensive unit tests for due date functionality

## Usage

```bash
# Create a task with a due date
taskmaster add "Complete report" --due 2024-06-15

# List tasks (shows due dates, overdue tasks in red)
taskmaster list

# Show task details including due date
taskmaster show abc123
```

## Link to Devin run
https://app.devin.ai/sessions/4840d3180ca24e91afe1c03bbd1a4a93

Requested by: kateaglaser@gmail.com (@katherineglaser7)

Closes #4